### PR TITLE
Adds Capability to expose Healthcheck on Application port for LB's which can't poll on admin port.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Dropwizard Oor Bundle [![Travis build status](https://travis-ci.org/phaneesh/dropwizard-oor.svg?branch=master)](https://travis-ci.org/phaneesh/dropwizard-oor)
 
 This bundle adds a healthcheck which can used to take the application out of rotation from
-a loadbalancer which uses /healthcheck endpoint for healthchecks
+a loadbalancer which uses /healthcheck endpoint for healthchecks.
+Also gives capability to expose admin port /healthcheck on application port for lb's which poll on application port.
 This bundle compiles only on Java 11.
  
 ## Usage
@@ -22,7 +23,7 @@ This makes it easier perform rolling deployments & maintenance of dropwizard app
 <dependency>
     <groupId>io.dropwizard.oor</groupId>
     <artifactId>dropwizard-oor</artifactId>
-    <version>2.0.24-1</version>
+    <version>2.0.24-2</version>
 </dependency>
 ```
 
@@ -34,9 +35,17 @@ This makes it easier perform rolling deployments & maintenance of dropwizard app
     public void initialize(final Bootstrap...) {
         bootstrap.addBundle(new OorBundle() {
             
+            @Override
             public boolean withOor() {
                 return false;
             }
+            
+            //Use this only if you require healthcheck on application port
+            @Override
+            public boolean exposeApplicationPortHealthCheck() {
+                return true;
+            }
+
             
         });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.raven.dropwizard</groupId>
     <artifactId>dropwizard-oor</artifactId>
-    <version>2.0.24-1</version>
+    <version>2.0.24-2</version>
     <packaging>jar</packaging>
 
     <name>dropwizard-oor</name>

--- a/src/main/java/io/dropwizard/oor/OorBundle.java
+++ b/src/main/java/io/dropwizard/oor/OorBundle.java
@@ -18,6 +18,7 @@ package io.dropwizard.oor;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
 import io.dropwizard.oor.healtcheck.OorHealthCheck;
+import io.dropwizard.oor.resources.HealthCheckResource;
 import io.dropwizard.oor.tasks.BirTask;
 import io.dropwizard.oor.tasks.OorTask;
 import io.dropwizard.setup.Bootstrap;
@@ -42,5 +43,13 @@ public abstract class OorBundle<T extends Configuration> implements ConfiguredBu
         environment.healthChecks().register("oor", new OorHealthCheck(withOor()));
         environment.admin().addTask(new OorTask());
         environment.admin().addTask(new BirTask());
+        if (exposeApplicationPortHealthCheck()) {
+            environment.jersey().register(new HealthCheckResource(environment.healthChecks()));
+        }
+    }
+
+    protected boolean exposeApplicationPortHealthCheck() {
+        //Client to over-ride if healthCheck resource required at application port
+        return false;
     }
 }

--- a/src/main/java/io/dropwizard/oor/resources/HealthCheckResource.java
+++ b/src/main/java/io/dropwizard/oor/resources/HealthCheckResource.java
@@ -1,0 +1,37 @@
+package io.dropwizard.oor.resources;
+
+import com.codahale.metrics.health.HealthCheckRegistry;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import lombok.val;
+
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/healthcheck/status")
+public class HealthCheckResource {
+
+  private HealthCheckRegistry registry;
+
+  public HealthCheckResource(HealthCheckRegistry registry) {
+    this.registry = registry;
+  }
+
+  @GET
+  public Response getHealthcheckStatus() {
+    val healthCheck = registry.runHealthChecks().entrySet();
+    return healthCheck.stream()
+        .filter(entry -> !entry.getValue().isHealthy())
+        .findFirst()
+        .map(result ->
+            Response.serverError()
+                .entity(healthCheck)
+                .build()
+        )
+        .orElse(Response.ok()
+            .entity(healthCheck)
+            .build());
+  }
+
+}


### PR DESCRIPTION
Adds a custom resource HealthCheckResource and a healthcheck API at /healthcheck/status
Which uses the HealthCheckRegistry to run all registered healthchecks and return a status code 200: basis all registered healthchecks being healthy OR a 500: basis at-least one healthcheck failing. Basically mocking the default /healthcheck behavior.

Adding this custom resource for LoadBalancers like Traefik which cannot poll on the admin port /healthcheck to determine when to take the app OOR.